### PR TITLE
Fix default-theme

### DIFF
--- a/settings/theming.yaml
+++ b/settings/theming.yaml
@@ -1,4 +1,4 @@
-theme: hack-blog
+theme: hackcss
 default_layout: default
 default_page_template: default
 default_entry_template: page


### PR DESCRIPTION
Default theme is set to hack-blog but the theme folder name is hackcss.